### PR TITLE
Remove .env in favor of lilac config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-DATABASE_URL="postgres://postgres:password@localhost/database"

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ venv/
 
 *.toml
 !Cargo.toml
-!lilac-config.example.toml
+!lilac.example.toml
 **/toolchain/*
 dist
 .DS_Store

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,7 +65,7 @@ To get Lilac up and running locally, you'll need to set up the backend, frontend
 
 1.  **Clone the repository.**
 2.  **Set up a PostgreSQL database.**
-3.  **Configure Environment:** Copy `.env.example` to `.env` and configure the `DATABASE_URL` and other settings.
+3.  **Configure Environment:** Copy `backend/.env.example` to `backend/.env` and optionally configure the `DATABASE_URL` and other settings.
 4.  **Run Database Migrations:** From the `backend` directory, run:
     ```bash
     sqlx migrate run

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -sSL https://raw.githubusercontent.com/getlilac/lilac/main/scripts/install.
 
 **2. Run the Lilac Platform**
 
-First run `cp .env.example .env` to create a dotenv file.
+First run `cp ./backend/lilac.example.toml ./backend/lilac.toml` to create the Lilac config file.
 
 Then to run Lilac using docker compose, simply run the following command. This will start a local PostgreSQL container, the Lilac backend (http://localhost:8081), and the Lilac web UI (http://localhost:8080).
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+# use cached queries instead of compile time SQL checks
+SQLX_OFFLINE=true
+# check your SQL queries against a locally running postgres instance
+# DATABASE_URL=postgres://lilac-user:password@localhost/lilac

--- a/backend/lilac.example.toml
+++ b/backend/lilac.example.toml
@@ -3,3 +3,7 @@ http_port = 8081
 secret_key = "a_secret_key_that_is_at_least_64_characters_long_0123456789abcde"
 log_format = "pretty"
 log_level = "info"
+# set the following to limit what users can sign up
+# allowed_usernames = ["admin"]
+# set this to `true` to disable sign ups entirely
+disable_sign_up = false

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,8 +8,6 @@ services:
       db:
         condition: service_healthy
         required: false
-    env_file:
-      - ../.env
     environment:
       - LILAC__DATABASE_URL=postgres://lilac-user:password@db/lilac
       - LILAC_CONFIG_FILE=/opt/lilac/api/lilac.toml
@@ -25,8 +23,6 @@ services:
     command: serve -s dist -l 8080
     depends_on:
       - backend
-    env_file:
-      - ../.env
     environment:
       - VITE_LILAC_API_ENDPOINT="http://localhost:8081"
     ports:


### PR DESCRIPTION
- update quickstart to use lilac config instead of .env.
- add .env.example in backend folder

Closes #7 