### PR TITLE
fix: Cluster name validation and error message on create form

### DIFF
--- a/frontend/src/features/clusters/forms/create-cluster-form.tsx
+++ b/frontend/src/features/clusters/forms/create-cluster-form.tsx
@@ -19,7 +19,11 @@ import createFormStore from '@/store/use-form-data';
 import { Input } from '@/components/ui/input';
 
 const clusterSchema = z.object({
-  clusterName: z.string(),
+  clusterName: z
+    .string({
+      error: 'Cluster name is required.',
+    })
+    .min(1, { message: 'Cluster name cannot be empty.' }),
   clusterDescription: z.string().optional(),
 });
 


### PR DESCRIPTION
PR addresses the following issues:

1. Fixes a bug where a user could submit the form with an empty cluster name after typing and deleting the text.
2. Improves the error message for the required cluster name field, making it more user-friendly.