### PR TITLE
perf: Only query on dead nodes in scheduler dead node cleanup

### DIFF
--- a/backend/src/domain/cluster/ports.rs
+++ b/backend/src/domain/cluster/ports.rs
@@ -40,6 +40,10 @@ pub trait ClusterRepository: Send + Sync {
         id: &ClusterId,
     ) -> Result<Vec<TrainingJob>, ClusterRepositoryError>;
     async fn list_all_nodes(&self) -> Result<Vec<ClusterNode>, ClusterRepositoryError>;
+    async fn list_nodes_older_than(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<ClusterNode>, ClusterRepositoryError>;
     async fn list_cluster_nodes(
         &self,
         id: &ClusterId,

--- a/backend/src/domain/scheduler/service.rs
+++ b/backend/src/domain/scheduler/service.rs
@@ -55,30 +55,28 @@ impl SchedulerService {
 
     async fn cleanup_dead_nodes(&self) -> Result<(), SchedulerServiceError> {
         info!("Running dead node cleanup...");
-        let nodes = self.cluster_repo.list_all_nodes().await?;
+        let cutoff = Utc::now() - chrono::Duration::seconds(90);
+        let nodes = self.cluster_repo.list_nodes_older_than(cutoff).await?;
         for node in nodes {
-            let since_heartbeat = Utc::now() - node.heartbeat_timestamp;
-            if since_heartbeat > chrono::Duration::seconds(90) {
-                info!("Found dead node {}. Cleaning up.", node.id);
+            info!("Found dead node {}. Cleaning up.", node.id);
 
-                if let Some(job_id) = node.assigned_job_id {
-                    info!(
-                        "Re-queueing assigned job {} from dead node {}",
-                        job_id, node.id
-                    );
-                    self.job_repo.reset_job_status(&job_id).await?;
-                }
-
-                if let Some(job_id) = node.reported_job_id {
-                    info!(
-                        "Re-queueing reported job {} from dead node {}",
-                        job_id, node.id
-                    );
-                    self.job_repo.reset_job_status(&job_id).await?;
-                }
-
-                self.cluster_repo.delete_cluster_node(&node.id).await?;
+            if let Some(job_id) = node.assigned_job_id {
+                info!(
+                    "Re-queueing assigned job {} from dead node {}",
+                    job_id, node.id
+                );
+                self.job_repo.reset_job_status(&job_id).await?;
             }
+
+            if let Some(job_id) = node.reported_job_id {
+                info!(
+                    "Re-queueing reported job {} from dead node {}",
+                    job_id, node.id
+                );
+                self.job_repo.reset_job_status(&job_id).await?;
+            }
+
+            self.cluster_repo.delete_cluster_node(&node.id).await?;
         }
         Ok(())
     }
@@ -313,9 +311,9 @@ mod tests {
 
         let mut cluster_repo = MockClusterRepository::new();
         cluster_repo
-            .expect_list_all_nodes()
+            .expect_list_nodes_older_than()
             .times(1)
-            .returning(move || Ok(vec![stale_node.clone()]));
+            .returning(move |_| Ok(vec![stale_node.clone()]));
         cluster_repo
             .expect_delete_cluster_node()
             .with(eq(stale_node_id.clone()))
@@ -468,8 +466,12 @@ mod tests {
 
         let mut cluster_repo = MockClusterRepository::new();
         cluster_repo
+            .expect_list_nodes_older_than()
+            .times(1)
+            .returning(|_| Ok(vec![]));
+        cluster_repo
             .expect_list_all_nodes()
-            .times(2)
+            .times(1)
             .returning(|| Ok(vec![]));
         cluster_repo
             .expect_list_cluster_nodes()

--- a/backend/src/domain/scheduler/service.rs
+++ b/backend/src/domain/scheduler/service.rs
@@ -259,3 +259,236 @@ impl SchedulerService {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        cluster::{
+            models::{ClusterId, ClusterNode},
+            ports::MockClusterRepository,
+        },
+        queue::{models::Queue, ports::MockQueueRepository},
+        training_job::{
+            models::{TrainingJob, TrainingJobStatus},
+            ports::MockTrainingJobRepository,
+        },
+    };
+    use mockall::predicate::{eq};
+
+    fn build_service(
+        job_repo: Arc<MockTrainingJobRepository>,
+        queue_repo: Arc<MockQueueRepository>,
+        cluster_repo: Arc<MockClusterRepository>,
+    ) -> SchedulerService {
+        let agent_adapter = Arc::new(AgentSchedulerAdapter::new(cluster_repo.clone()));
+        SchedulerService::new(job_repo, queue_repo, cluster_repo, agent_adapter)
+    }
+
+    #[tokio::test]
+    async fn cleanup_dead_nodes_requeues_jobs_and_deletes_stale_node() {
+
+        // Create a stale node
+        let mut stale_node = ClusterNode::new_mock();
+        stale_node.heartbeat_timestamp = Utc::now() - chrono::Duration::seconds(91);
+        stale_node.assigned_job_id = Some(crate::domain::training_job::models::JobId::generate());
+        stale_node.reported_job_id = Some(crate::domain::training_job::models::JobId::generate());
+
+        let assigned_job_id = stale_node.assigned_job_id.clone().unwrap();
+        let reported_job_id = stale_node.reported_job_id.clone().unwrap();
+        let stale_node_id = stale_node.id.clone();
+
+        let mut job_repo = MockTrainingJobRepository::new();
+        job_repo
+            .expect_reset_job_status()
+            .with(eq(assigned_job_id.clone()))
+            .times(1)
+            .returning(|_| Ok(()));
+        job_repo
+            .expect_reset_job_status()
+            .with(eq(reported_job_id.clone()))
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let queue_repo = MockQueueRepository::new();
+
+        let mut cluster_repo = MockClusterRepository::new();
+        cluster_repo
+            .expect_list_all_nodes()
+            .times(1)
+            .returning(move || Ok(vec![stale_node.clone()]));
+        cluster_repo
+            .expect_delete_cluster_node()
+            .with(eq(stale_node_id.clone()))
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let service = build_service(
+            Arc::new(job_repo),
+            Arc::new(queue_repo),
+            Arc::new(cluster_repo),
+        );
+
+        service.cleanup_dead_nodes().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_stale_starting_jobs_cancels_when_queue_is_missing() {
+        let mut job = TrainingJob::new_mock();
+        job.status = TrainingJobStatus::Starting;
+        job.node_id = Some(crate::domain::cluster::models::NodeId::generate());
+        job.queue_id = Some(crate::domain::queue::models::QueueId::generate());
+
+        let job_id = job.id.clone();
+        let node_id = job.node_id.clone().unwrap();
+        let queue_id = job.queue_id.clone().unwrap();
+
+        let mut job_repo = MockTrainingJobRepository::new();
+        job_repo
+            .expect_get_jobs_by_status()
+            .with(eq(TrainingJobStatus::Starting))
+            .times(1)
+            .returning(move |_| Ok(vec![job.clone()]));
+        job_repo
+            .expect_update_status()
+            .with(eq(job_id.clone()), eq(TrainingJobStatus::Cancelled))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        job_repo.expect_reset_job_status().times(0);
+
+        let mut queue_repo = MockQueueRepository::new();
+        queue_repo
+            .expect_get_queue_by_id()
+            .with(eq(queue_id.clone()))
+            .times(1)
+            .returning(|_| Err(QueueRepositoryError::NotFound("missing-queue".to_string())));
+
+        let mut cluster_repo = MockClusterRepository::new();
+        cluster_repo
+            .expect_get_cluster_node_by_id()
+            .with(eq(node_id.clone()))
+            .times(1)
+            .returning(|_| Ok(ClusterNode::new_mock()));
+
+        let service = build_service(
+            Arc::new(job_repo),
+            Arc::new(queue_repo),
+            Arc::new(cluster_repo),
+        );
+
+        service.cleanup_stale_starting_jobs().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_preempted_jobs_requeues_non_terminal_reported_job() {
+        let job = TrainingJob {
+            status: TrainingJobStatus::Running,
+            ..TrainingJob::new_mock()
+        };
+        let job_id = job.id.clone();
+
+        let mut node = ClusterNode::new_mock();
+        node.assigned_job_id = None;
+        node.reported_job_id = Some(job_id.clone());
+
+        let mut job_repo = MockTrainingJobRepository::new();
+        job_repo
+            .expect_get_training_job_by_id()
+            .with(eq(job_id.clone()))
+            .times(1)
+            .returning(move |_| Ok(job.clone()));
+        job_repo
+            .expect_reset_job_status()
+            .with(eq(job_id.clone()))
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let queue_repo = MockQueueRepository::new();
+
+        let mut cluster_repo = MockClusterRepository::new();
+        cluster_repo
+            .expect_list_all_nodes()
+            .times(1)
+            .returning(move || Ok(vec![node.clone()]));
+
+        let service = build_service(
+            Arc::new(job_repo),
+            Arc::new(queue_repo),
+            Arc::new(cluster_repo),
+        );
+
+        service.cleanup_preempted_jobs().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_cycle_marks_job_starting_when_agent_finds_capacity() {
+        let cluster_id = ClusterId::generate();
+
+        let mut queue = Queue::new_mock();
+        queue.cluster_targets = vec![cluster_id.clone()];
+        let queue_id = queue.id.clone();
+
+        let mut job = TrainingJob::new_mock();
+        job.queue_id = Some(queue_id.clone());
+        let job_id = job.id.clone();
+        let resource_requirements = job.resource_requirements.clone();
+
+        let mut schedulable_node = ClusterNode::new_mock();
+        schedulable_node.cluster_id = cluster_id.clone();
+        schedulable_node.cpu.millicores = resource_requirements.cpu_millicores;
+        schedulable_node.memory_mb = resource_requirements.memory_mb;
+        let node_id = schedulable_node.id.clone();
+
+        let mut job_repo = MockTrainingJobRepository::new();
+        job_repo
+            .expect_get_jobs_by_status()
+            .with(eq(TrainingJobStatus::Starting))
+            .times(1)
+            .returning(|_| Ok(vec![]));
+        job_repo
+            .expect_get_jobs_by_status()
+            .with(eq(TrainingJobStatus::Queued))
+            .times(1)
+            .returning(|_| Ok(vec![]));
+        job_repo
+            .expect_get_queued_jobs_for_queue()
+            .with(eq(queue_id.clone()))
+            .times(1)
+            .returning(move |_| Ok(vec![job.clone()]));
+        job_repo
+            .expect_mark_as_starting()
+            .with(eq(job_id.clone()), eq(node_id.clone()))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let mut queue_repo = MockQueueRepository::new();
+        queue_repo
+            .expect_get_all_queues_sorted()
+            .times(1)
+            .returning(move || Ok(vec![queue.clone()]));
+
+        let mut cluster_repo = MockClusterRepository::new();
+        cluster_repo
+            .expect_list_all_nodes()
+            .times(2)
+            .returning(|| Ok(vec![]));
+        cluster_repo
+            .expect_list_cluster_nodes()
+            .with(eq(cluster_id.clone()))
+            .times(1)
+            .returning(move |_| Ok(vec![schedulable_node.clone()]));
+        cluster_repo
+            .expect_assign_job_to_node()
+            .with(eq(node_id.clone()), eq(job_id.clone()))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let service = build_service(
+            Arc::new(job_repo),
+            Arc::new(queue_repo),
+            Arc::new(cluster_repo),
+        );
+
+        service.run_cycle().await.unwrap();
+    }
+}

--- a/backend/src/domain/scheduler/service.rs
+++ b/backend/src/domain/scheduler/service.rs
@@ -288,7 +288,6 @@ mod tests {
     #[tokio::test]
     async fn cleanup_dead_nodes_requeues_jobs_and_deletes_stale_node() {
 
-        // Create a stale node
         let mut stale_node = ClusterNode::new_mock();
         stale_node.heartbeat_timestamp = Utc::now() - chrono::Duration::seconds(91);
         stale_node.assigned_job_id = Some(crate::domain::training_job::models::JobId::generate());

--- a/backend/src/outbound/persistence/postgres/cluster_repository.rs
+++ b/backend/src/outbound/persistence/postgres/cluster_repository.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use sqlx::PgPool;
+use chrono::{DateTime, Utc};
 
 use crate::{
     domain::{
@@ -178,6 +179,24 @@ impl ClusterRepository for PostgresClusterRepository {
             SELECT node_id, cluster_id, node_status as "node_status: NodeStatusRecord", heartbeat_timestamp, memory_mb, cpu as "cpu: CpuConfigurationRecord", gpus as "gpus: Vec<GpuConfigurationRecord>", created_at, updated_at, assigned_job_id, reported_job_id
             FROM cluster_nodes
             "#,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e: sqlx::Error| ClusterRepositoryError::Unknown(anyhow::anyhow!(e)))?;
+
+        let nodes: Vec<ClusterNode> = records.into_iter().map(|r| r.into()).collect();
+        Ok(nodes)
+    }
+
+    async fn list_nodes_older_than(&self, cutoff: DateTime<Utc>) -> Result<Vec<ClusterNode>, ClusterRepositoryError> {
+        let records = sqlx::query_as!(
+            ClusterNodeRecord,
+            r#"
+            SELECT node_id, cluster_id, node_status as "node_status: NodeStatusRecord", heartbeat_timestamp, memory_mb, cpu as "cpu: CpuConfigurationRecord", gpus as "gpus: Vec<GpuConfigurationRecord>", created_at, updated_at, assigned_job_id, reported_job_id
+            FROM cluster_nodes
+            WHERE heartbeat_timestamp < $1
+            "#,
+            cutoff,
         )
         .fetch_all(&self.pool)
         .await


### PR DESCRIPTION
Currently, dead node clean up in scheduler queries for all nodes, iterates every node in rust, then reschedules the job and cleans up the node from queue. 

With this change, we will move the logic around "is this node dead?" into the db query. Then, in the scheduler, we only iterate through dead nodes and we can reschedule and clean up on nodes we know are dead.

1) less data read from Postgres
2) fewer rows sent over the network
3) less scheduler iteration and object construction
4) cleaner separation -- DB does filtering, service does cleanup

Follow up PR based on: https://github.com/getlilac/lilac/pull/25
